### PR TITLE
Operator Controller Update

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -130,7 +130,7 @@ public final class Constants {
     public static final int FeederRightCanId = 12;
 
     public static final double FeederInSpeed = -0.3;
-    public static final double FeederOutSpeed = 0.2;
+    public static final double FeederOutSpeed = 0.15;
     public static final double FeederToShooterSpeed = -0.45;
 
     public static final int kPneumaticHubCanId = 50;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -122,7 +122,7 @@ public class RobotContainer {
 
     // Feeder Out
     cutil
-        .supplier(Controllers.ps4_triangle, DriveConstants.joysticks.OPERATOR)
+        .supplier(Controllers.ps4_share, DriveConstants.joysticks.OPERATOR)
         .onTrue(new OutFeederCmd(feeder))
         .onFalse(new StopFeederCmd(feeder));
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -91,13 +91,13 @@ public class RobotContainer {
         .onTrue(new InstantCommand(() -> shooter.ShooterForwardCmd(1, 1)))
         .onFalse(new ShooterStopCmd(shooter));
 
-    // Speaker Left Bank Shot (Driverstation POV)
+    // Speaker Right Bank Shot (Driverstation POV)
     cutil
         .supplier(Controllers.ps4_O, joysticks.OPERATOR)
         .onTrue(new InstantCommand(() -> shooter.ShooterForwardCmd(1, 0.8)))
         .onFalse(new ShooterStopCmd(shooter));
 
-    // Speaker Right Bank Shot (Driverstation POV)
+    // Speaker Left Bank Shot (Driverstation POV)
     cutil
         .supplier(Controllers.ps4_square, joysticks.OPERATOR)
         .onTrue(new InstantCommand(() -> shooter.ShooterForwardCmd(0.8, 1)))

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -65,7 +65,7 @@ public class RobotContainer {
   public RobotContainer() {
     // Declare default command during Teleop Period as TeleopCmd(Driving Command)
     drivetrain.setDefaultCommand(teleopCmd);
-    // Shooter Controls
+    // Amp Shot
     shooter.setDefaultCommand(new ShooterForwardCmd(shooter));
 
     // Add Auto options to dropdown and push to dashboard
@@ -85,11 +85,29 @@ public class RobotContainer {
     // Prior Reference:
     // https://github.com/OysterRiverOverdrive/Charged-Up-2023-Atlas_Chainsaw/blob/main/src/main/java/frc/robot/RobotContainer.java
 
+    // Speaker Straight Shot
+    cutil
+        .supplier(Controllers.ps4_X, joysticks.OPERATOR)
+        .onTrue(new InstantCommand(() -> shooter.ShooterForwardCmd(1, 1)))
+        .onFalse(new ShooterStopCmd(shooter));
+
+    // Speaker Left Bank Shot (Driverstation POV)
+    cutil
+        .supplier(Controllers.ps4_O, joysticks.OPERATOR)
+        .onTrue(new InstantCommand(() -> shooter.ShooterForwardCmd(1, 0.8)))
+        .onFalse(new ShooterStopCmd(shooter));
+
+    // Speaker Right Bank Shot (Driverstation POV)
+    cutil
+        .supplier(Controllers.ps4_square, joysticks.OPERATOR)
+        .onTrue(new InstantCommand(() -> shooter.ShooterForwardCmd(0.8, 1)))
+        .onFalse(new ShooterStopCmd(shooter));
+
     // Hangers Up
-    cutil.POVsupplier(0, joysticks.OPERATOR).onTrue(new HangerUpCmd(hanger));
+    cutil.POVsupplier(180, joysticks.OPERATOR).onTrue(new HangerUpCmd(hanger));
 
     // Hangers Down
-    cutil.POVsupplier(180, joysticks.OPERATOR).onTrue(new HangerDownCmd(hanger));
+    cutil.POVsupplier(0, joysticks.OPERATOR).onTrue(new HangerDownCmd(hanger));
 
     // Zero Heading
     cutil
@@ -104,7 +122,7 @@ public class RobotContainer {
 
     // Feeder Out
     cutil
-        .supplier(Controllers.ps4_share, DriveConstants.joysticks.OPERATOR)
+        .supplier(Controllers.ps4_triangle, DriveConstants.joysticks.OPERATOR)
         .onTrue(new OutFeederCmd(feeder))
         .onFalse(new StopFeederCmd(feeder));
 

--- a/src/main/java/frc/robot/commands/Shooter/ShooterForwardCmd.java
+++ b/src/main/java/frc/robot/commands/Shooter/ShooterForwardCmd.java
@@ -34,7 +34,7 @@ public class ShooterForwardCmd extends Command {
   public void execute() {
     // trigger value (how far it's pushed in) is set as the speed of the motor
     double trigValue = oper.getRawAxis(Controllers.ps4_RT);
-    shooter.ShooterForwardCmd(trigValue * 0.35, trigValue * 0.35);
+    shooter.ShooterForwardCmd(trigValue * 0.6, trigValue * 0.6);
 
     double degreeout = RobotConstants.kAmpArmDegreesOut / 360; // Convert to percentage of rotation
     if (trigValue >= RobotConstants.kAmpArmTrigActivate) {

--- a/src/main/java/frc/robot/commands/Shooter/ShooterForwardCmd.java
+++ b/src/main/java/frc/robot/commands/Shooter/ShooterForwardCmd.java
@@ -34,7 +34,7 @@ public class ShooterForwardCmd extends Command {
   public void execute() {
     // trigger value (how far it's pushed in) is set as the speed of the motor
     double trigValue = oper.getRawAxis(Controllers.ps4_RT);
-    shooter.ShooterForwardCmd(trigValue, trigValue * .85);
+    shooter.ShooterForwardCmd(trigValue * 0.35, trigValue * 0.35);
 
     double degreeout = RobotConstants.kAmpArmDegreesOut / 360; // Convert to percentage of rotation
     if (trigValue >= RobotConstants.kAmpArmTrigActivate) {


### PR DESCRIPTION
Controls were changed to the following
On the operator controller
Changed:
Right Trigger - Amp Shooting (60% with the amp arm spinning out)
Share Button - Spin feeder backward (Slower)

New: Shooter Buttons without Amp Arm
X Button - Straight shot at speaker (No spin, 100% right & left side)
O Button - Bank shot at speaker, from the right side of Driverstation POV (100% left side, 80% right side)
Square Button - Bank shot at speaker, from the left side of Driverstation POV (80% left side, 100% right side)
