### PR TITLE
New method getAlliancePose2d to get Pose2d directly from Limelight

### DIFF
--- a/src/main/java/frc/robot/subsystems/LimelightSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LimelightSubsystem.java
@@ -133,7 +133,7 @@ public class LimelightSubsystem extends SubsystemBase {
 
   public Pose2d getAlliancePose2d() {
     double poseArray[] = getAbsoluteBotPose();
-    return new Pose2d(poseArray[0], poseArray[1], new Rotation2d(poseArray[5]));
+    return new Pose2d(poseArray[0], poseArray[1], Rotation2d.fromDegrees(poseArray[5]));
   }
 
   public int getAprilTagID() {

--- a/src/main/java/frc/robot/subsystems/LimelightSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LimelightSubsystem.java
@@ -4,6 +4,8 @@
 
 package frc.robot.subsystems;
 
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
@@ -127,6 +129,11 @@ public class LimelightSubsystem extends SubsystemBase {
     } else {
       return botpose_wpired.getDoubleArray(new double[6]);
     }
+  }
+
+  public Pose2d getAlliancePose2d() {
+    double poseArray[] = getAbsoluteBotPose();
+    return new Pose2d(poseArray[0], poseArray[1], new Rotation2d(poseArray[5]));
   }
 
   public int getAprilTagID() {


### PR DESCRIPTION
Limelight botpose returns a 6 element array (with angles in degrees) but we really just need a Pose2d (x, y, and yaw in radians). Added a function for this. 